### PR TITLE
Install numpy in setup.py, so the package can be installed without the need to have numpy installed before installation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,8 +2,10 @@ import os
 import platform
 from setuptools import setup, Extension, find_packages
 
-import numpy as np
-
+try:
+    import numpy as np
+except:
+    print('Setup.py requires numpy.\nPlease run:\n\tpip install numpy')
 extra_compile_args = []
 if platform.system().lower() == 'windows':
     # This may fail if compiled on Windows with a compiler

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ try:
     import numpy as np
 except:
     print('Setup.py requires numpy.\nPlease run:\n\tpip install numpy')
-    exit(1s)
+    exit(1)
 extra_compile_args = []
 if platform.system().lower() == 'windows':
     # This may fail if compiled on Windows with a compiler

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,14 @@
 import os
 import platform
 from setuptools import setup, Extension, find_packages
+import pip
 
 try:
     import numpy as np
-except:
-    print('Setup.py requires numpy.\nPlease run:\n\tpip install numpy')
-    exit(1)
+except ImportError:
+    pip.main(['install', 'numpy'])
+    import numpy as np
+
 extra_compile_args = []
 if platform.system().lower() == 'windows':
     # This may fail if compiled on Windows with a compiler
@@ -14,6 +16,10 @@ if platform.system().lower() == 'windows':
     # like mingw
     extra_compile_args = ['/EHsc']
 
+try:
+    from Cython.Build import cythonize
+except:
+    pip.main(['install', 'cython'])
 
 try:
     from Cython.Build import cythonize

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,7 @@ try:
     import numpy as np
 except:
     print('Setup.py requires numpy.\nPlease run:\n\tpip install numpy')
+    exit(1s)
 extra_compile_args = []
 if platform.system().lower() == 'windows':
     # This may fail if compiled on Windows with a compiler

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,15 @@
 import os
 import platform
 from setuptools import setup, Extension, find_packages
-import pip
+try:
+    from pip import main as pipmain
+except:
+    from pip._internal import main as pipmain
 
 try:
     import numpy as np
 except ImportError:
-    pip.main(['install', 'numpy'])
+    pipmain(['install', 'numpy'])
     import numpy as np
 
 extra_compile_args = []
@@ -19,7 +22,7 @@ if platform.system().lower() == 'windows':
 try:
     from Cython.Build import cythonize
 except:
-    pip.main(['install', 'cython'])
+    pipmain(['install', 'cython'])
 
 try:
     from Cython.Build import cythonize


### PR DESCRIPTION
Installing pynumpress fail, when numpy is not installed on the system, even though its in requirements.
This is due to the fact that the requirements are built before setup.py, but not installed.
Since cython requires numpy, we need to make sure numpy is installed when setup.py is executed.
This pull requests introduces a setup.py version, where numpy is installed before building the package